### PR TITLE
Fix keyboard shortcut for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To insert or change a selected color, use:
 
 - Linux: `ctrl+shift+c`
 - Windows: `ctrl+shift+c`
-- OS X: `super+shift+c`
+- OS X: `cmd+shift+c`
 
 
 ## Acknowledgements


### PR DESCRIPTION
As specified in the original plugin, it's `cmd+shift+c`, not `super+shift+c`
