### PR TITLE
Command Palette, capitalize "P" in "Color Picker"

### DIFF
--- a/ColorPicker.sublime-commands
+++ b/ColorPicker.sublime-commands
@@ -1,4 +1,4 @@
 [{
-	"caption": "Color picker",
+	"caption": "Color Picker",
 	"command": "color_pick"
 }]


### PR DESCRIPTION
This is nitpicky, but to keep with Sublime's Command Palette standard seen in all of it's available commands, I propose capitalizing the word "Picker" :)
