### PR TITLE
Added support for more Linux Distros

### DIFF
--- a/lib/linux_colorpicker.py
+++ b/lib/linux_colorpicker.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
-from gi.repository import Gtk
 import sys
+
+try:
+    from gi.repository import Gtk
+except ImportError:
+    import gtk as Gtk
 
 try:
     Gdk = Gtk.gdk
@@ -18,7 +22,8 @@ if len(sys.argv) > 1:
         except AttributeError:  # newer version of GTK
             color_sel.get_color_selection().set_current_color(current_color)
 
-if color_sel.run() == Gtk.ResponseType.OK:
+
+if color_sel.run() == getattr(Gtk, 'RESPONSE_OK', Gtk.ResponseType.Ok):
     color = color_sel.get_color_selection().get_current_color()
     #Convert to 8bit channels
     red = int(color.red / 256)


### PR DESCRIPTION
**Problem:**
On certain linux distros (tested on RedHat Enterprise) an older version of Py GTK is installed by default. This commit adds support for older versions of PyGTK (specifically 2 instead of the newer version 3).

**Solution:**
Provide backwards compatibility for GTK2, without hurting support for GTK3.

**Testing:**
Tested that the color picker:
* opens
* is cancelable/closeable
* color chosen is passed back to sublime
* if the user had previously selected a color in sublime, the color picker is pre-filled with that color
... in GTK 2 environment.

Also tested for GTK3, which was already supported.

Fixes #65 