### PR TITLE
 add Tools->ColorPicker action

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,5 +1,16 @@
 [
     {
+        "caption": "Tools",
+        "mnemonic": "T",
+        "id": "tools",
+        "children": [
+            {
+                "caption": "ColorPicker",
+                "command": "color_pick"
+            }
+        ]
+    },
+    {
         "caption": "Preferences",
         "children": [
             {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ To insert or change a selected color, use:
 - Windows: `ctrl+shift+c`
 - OS X: `cmd+shift+c`
 
+or use menu action
+
+- **`Tools`** -> **`ColorPicker`**
+
+
 By default, the hex color code is inserted using uppercase letters. To use lowercase letters instead, copy the contents of **`Preferences -> Package Settings -> ColorPicker -> Settings-Default`** to the empty file created by selecting **`Preferences -> Package Settings -> ColorPicker -> Settings-User`**, then change `"color_upper_case"` to `false`.
 
 ## Calling from Other Plugins


### PR DESCRIPTION
The keyboard shortcuts might conflict with other plugin. 
added a menu action to make a another approach to access to ColorPicker.