### PR TITLE
Fixed linux error

### DIFF
--- a/lib/linux_colorpicker.py
+++ b/lib/linux_colorpicker.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
-
 wx = None
 Gtk = None
 
@@ -9,6 +8,7 @@ try:
     import gi
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gtk
+    from gi.repository import Gdk
 except ImportError:
     try:
         import gtk as Gtk
@@ -24,7 +24,6 @@ except ImportError:
 
 def open_color_picker_via_gtk():
     color_sel = Gtk.ColorSelectionDialog("Sublime Color Picker")
-
     if len(sys.argv) > 1:
         current_color = Gdk.color_parse(sys.argv[1])
         if current_color:

--- a/sublimecp.py
+++ b/sublimecp.py
@@ -376,7 +376,6 @@ class ColorPickCommand(sublime_plugin.TextCommand):
             elif selected.startswith('0x'):
                 selected = selected[2:]
                 prefix = '0x'
-            print("AAa: "+ selected)
 
         cp = ColorPicker()
         color = cp.pick(self.view.window(), selected)

--- a/sublimecp.py
+++ b/sublimecp.py
@@ -4,10 +4,10 @@ import subprocess
 import os
 from stat import *
 
-sublime_version = 2
+sublime_version = 3
 
-if not sublime.version() or int(sublime.version()) > 3000:
-    sublime_version = 3
+if not sublime.version() or int(sublime.version()) > 4000:
+    sublime_version = 4
 
 if sublime.platform() == 'windows':
 
@@ -362,16 +362,21 @@ class ColorPickApiIsAvailableCommand(sublime_plugin.ApplicationCommand):
 class ColorPickCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         sel = self.view.sel()
+
         selected = None
         prefix = '#'
+        
         # get the currently selected color - if any
         if len(sel) > 0:
             selected = self.view.substr(self.view.word(sel[0])).strip()
             if selected.startswith('#'):
                 selected = selected[1:]
+            elif selected.startswith('\''):
+                selected = selected[2:]
             elif selected.startswith('0x'):
                 selected = selected[2:]
                 prefix = '0x'
+            print("AAa: "+ selected)
 
         cp = ColorPicker()
         color = cp.pick(self.view.window(), selected)


### PR DESCRIPTION
Under new linux versions (tested on Ubuntu 22.04), the color won't open.
Also fix a bug that doesn't show the selected color if the '#' was selected.